### PR TITLE
Update composer for older Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "PHP": ">=7.0.0",
-        "symfony/http-foundation": "~3.0.9|^4.0.4"
+        "symfony/http-foundation": "^3.0.9|^4.0.4"
     },
     "require-dev": {
         "symfony/form": "^3.0.9|^4.0.4",


### PR DESCRIPTION
The versioning is way too specific.  That is almost certainly a bug.  

As written:

https://semver.mwl.be/#?package=symfony%2Fhttp-foundation&version=~3.0.9%7C%5E4.0.4&minimum-stability=stable

Proposed fix:

https://semver.mwl.be/#?package=symfony%2Fhttp-foundation&version=%5E3.0.9%7C%5E4.0.4&minimum-stability=stable