### PR TITLE
Add Base64EncodedFileNormalizer for symfony/serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,12 @@
     },
     "require-dev": {
         "symfony/form": "^2.8 || ^3.0 || ^4.0",
+        "symfony/serializer": "^2.8 || ^3.0 || ^4.0",
         "phpunit/phpunit": "^6.5"
     },
     "suggest": {
-        "symfony/form": "to use base64_encoded_file type"
+        "symfony/form": "to use base64_encoded_file type",
+        "symfony/serializer": "to convert a base64 string to a Base64EncodedFile object"
     },
     "autoload": {
         "psr-4": {

--- a/src/Serializer/Base64EncodedFileNormalizer.php
+++ b/src/Serializer/Base64EncodedFileNormalizer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Hshn\Base64EncodedFile\Serializer;
+
+use Hshn\Base64EncodedFile\HttpFoundation\File\Base64EncodedFile;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+final class Base64EncodedFileNormalizer implements DenormalizerInterface
+{
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        return new Base64EncodedFile($data);
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return Base64EncodedFile::class === $type && \is_string($data);
+    }
+}

--- a/tests/Serializer/Base64EncodedFileNormalizerTest.php
+++ b/tests/Serializer/Base64EncodedFileNormalizerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hshn\Base64EncodedFile\Serializer;
+
+use Hshn\Base64EncodedFile\HttpFoundation\File\Base64EncodedFile;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+final class Base64EncodedFileNormalizerTest extends TestCase
+{
+    const BASE64_STRING = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
+
+    /**
+     * @var Base64EncodedFileNormalizer
+     */
+    private $normalizer;
+
+    protected function setUp()
+    {
+        $this->normalizer = new Base64EncodedFileNormalizer();
+    }
+
+    public function testItDoesNotSupportInvalidFormat()
+    {
+        $this->assertFalse($this->normalizer->supportsDenormalization(self::BASE64_STRING, 'invalid'));
+    }
+
+    public function testItDoesNotSupportInvalidData()
+    {
+        $this->assertFalse($this->normalizer->supportsDenormalization(3, Base64EncodedFile::class));
+    }
+
+    public function testItSupportsValidFormatAndData()
+    {
+        $this->assertTrue($this->normalizer->supportsDenormalization(self::BASE64_STRING, Base64EncodedFile::class));
+    }
+
+    public function testItDenormalizesAStringToABase64EncodedFileObject()
+    {
+        $this->assertInstanceOf(Base64EncodedFile::class, $this->normalizer->denormalize(self::BASE64_STRING, Base64EncodedFile::class));
+    }
+}


### PR DESCRIPTION
For API projects, not using forms but mainly serialization, it could be very useful to convert a base64 string to a Base64EncodedFile object.

As the component `symfony/serializer` is not compulsory to run this library, I just set it as suggest in the composer.json