### PR TITLE
Bundelize the lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,22 @@ $form = $formBuilder
     ->add('file', Base64EncodedFileType::class)
     ->getForm();
 ```
+
+
+### Integration in a Symfony project (manual install)
+
+Use this bundle in a Symfony project requires the following libraries:
+
+* symfony/dependency-injection
+* symfony/http-kernel
+* symfony/config
+
+Then, you can load the bundle through the following configuration:
+
+```php
+<?php
+
+// bundles.php
+
+Hshn\Base64EncodedFile\Bridge\Symfony\Bundle\Base64EncodedFileBundle::class => ['all' => true],
+```

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,17 @@
     "require-dev": {
         "symfony/form": "^2.8 || ^3.0 || ^4.0",
         "symfony/serializer": "^2.8 || ^3.0 || ^4.0",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^6.5",
+        "symfony/dependency-injection": "^2.8 || ^3.0 || ^4.0",
+        "symfony/config": "^2.8 || ^3.0 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0"
     },
     "suggest": {
         "symfony/form": "to use base64_encoded_file type",
-        "symfony/serializer": "to convert a base64 string to a Base64EncodedFile object"
+        "symfony/serializer": "to convert a base64 string to a Base64EncodedFile object",
+        "symfony/dependency-injection": "to use the bundle in a Symfony project",
+        "symfony/http-kernel": "to use the bundle in a Symfony project",
+        "symfony/config": "to use the bundle in a Symfony project"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bridge/Symfony/Bundle/Base64EncodedFileBundle.php
+++ b/src/Bridge/Symfony/Bundle/Base64EncodedFileBundle.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Hshn\Base64EncodedFile\Bridge\Symfony\Bundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+final class Base64EncodedFileBundle extends Bundle
+{
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Base64EncodedFileExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Base64EncodedFileExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Hshn\Base64EncodedFile\Bridge\Symfony\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+final class Base64EncodedFileExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/src/Bridge/Symfony/Resources/config/services.xml
+++ b/src/Bridge/Symfony/Resources/config/services.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Hshn\Base64EncodedFile\Serializer\Base64EncodedFileNormalizer" class="Hshn\Base64EncodedFile\Serializer\Base64EncodedFileNormalizer" public="false">
+            <tag name="serializer.normalizer" priority="1" />
+        </service>
+    </services>
+
+</container>


### PR DESCRIPTION
Add a bridge for a Symfony project implementation. The `Base64EncodedFileNormalizer` is in conflict with the `DataUriNormalizer` from `symfony/serializer`, cause they both normalize an instance of `File`. The `Base64EncodedFileNormalizer` must have a higher priority. It could be done manually by the developer, or automatically using Symfony bundle.

Would be awesome to add a recipe: https://github.com/symfony/recipes-contrib/