### PR TITLE
Fix php 8.1 depreciation message

### DIFF
--- a/src/Form/DataTransformer/FileToBase64EncodedStringTransformer.php
+++ b/src/Form/DataTransformer/FileToBase64EncodedStringTransformer.php
@@ -35,7 +35,7 @@ class FileToBase64EncodedStringTransformer implements DataTransformerInterface
             return '';
         }
 
-        if (false === $file = @file_get_contents($value->getPathname(), FILE_BINARY)) {
+        if (false === $file = @file_get_contents($value->getPathname())) {
             throw new TransformationFailedException(sprintf('Unable to read the "%s" file', $value->getPathname()));
         }
 

--- a/src/HttpFoundation/File/Base64EncodedFile.php
+++ b/src/HttpFoundation/File/Base64EncodedFile.php
@@ -84,7 +84,7 @@ class Base64EncodedFile extends File
             throw new FileException(sprintf('Unable to create a file into the "%s" directory', $directory));
         }
 
-        if (false === file_put_contents($path, $decoded, FILE_BINARY)) {
+        if (false === file_put_contents($path, $decoded)) {
             throw new FileException(sprintf('Unable to write the file "%s"', $path));
         }
 


### PR DESCRIPTION
FILE_BINARY constant is deprecated since php8.1 because this const have no effect :

https://wiki.php.net/rfc/deprecations_php_8_1
https://github.com/php/php-src/pull/5556
