### PR TITLE
Fix PHPstan validation error

### DIFF
--- a/src/HttpFoundation/File/UploadedBase64EncodedFile.php
+++ b/src/HttpFoundation/File/UploadedBase64EncodedFile.php
@@ -13,8 +13,8 @@ class UploadedBase64EncodedFile extends UploadedFile
     /**
      * @param Base64EncodedFile $file
      * @param string            $originalName
-     * @param null              $mimeType
-     * @param null              $size
+     * @param string|null       $mimeType
+     * @param int|null          $size
      */
     public function __construct(Base64EncodedFile $file, $originalName = '', $mimeType = null, $size = null)
     {


### PR DESCRIPTION
The error:
Parameter $mimeType of class Hshn\Base64EncodedFile\HttpFoundation\File\UploadedBase64EncodedFile  constructor expects null, string given.