### PR TITLE
build!: Drop outdated php 7 and 8.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,21 @@ jobs:
     strategy:
       matrix:
         include:
+          # symfony 7
+          - php: 8.3
           - php: 8.2
+          # symfony 6
+          - php: 8.3
+            composer-dependencies: symfony/symfony:^6
           - php: 8.2
-            composer-dependencies: symfony/symfony:^7
-          - php: 8.1
+            composer-dependencies: symfony/symfony:^6
           - php: 8.1
             composer-dependencies: symfony/symfony:^6
+          # symfony 5
+          - php: 8.3
+            composer-dependencies: symfony/symfony:^5
+          - php: 8.2
+            composer-dependencies: symfony/symfony:^5
           - php: 8.1
             composer-dependencies: symfony/symfony:^5
     steps:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.0 || ^8.0.0",
+        "php": "^8.1.0",
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
         "symfony/mime": "^5.4 || ^6.0 || ^7.0"
     },


### PR DESCRIPTION
PHP 7 and 8.0 had reached EOL

> <img width="1007" alt="image" src="https://github.com/hshn/base64-encoded-file/assets/1334026/6f1fb76b-685a-4648-9716-0af845b1de12">
>
>> https://www.php.net/supported-versions.php