### PR TITLE
fix: implicitly marking parameter $format as nullable is deprecated

### DIFF
--- a/src/Serializer/Base64EncodedFileNormalizer.php
+++ b/src/Serializer/Base64EncodedFileNormalizer.php
@@ -15,7 +15,7 @@ final class Base64EncodedFileNormalizer implements DenormalizerInterface
         return new Base64EncodedFile($data);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return Base64EncodedFile::class === $type && \is_string($data);
     }


### PR DESCRIPTION
fix 
```
vendor/hshn/base64-encoded-file/src/Serializer/Base64EncodedFileNormalizer.php:18
Hshn\Base64EncodedFile\Serializer\Base64EncodedFileNormalizer::supportsDenormalization(): Implicitly marking parameter $format as nullable is deprecated, the explicit nullable type must be used instead
```